### PR TITLE
rubocop.ymlを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+# "Missing top-level module documentation comment." を無効化
+Style/Documentation:
+  Enabled: false


### PR DESCRIPTION
### rubocop.ymlを追加

- "Missing top-level module documentation comment." を無効化

※ 他にも不要なチェックがあれば追加していく