### PR TITLE
不要な変数を削除

### DIFF
--- a/spec/support/selenium_chrome.rb
+++ b/spec/support/selenium_chrome.rb
@@ -8,7 +8,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   options.add_argument('--disable-dev-shm-usage')
   options.add_argument('--window-size=1400,1400')
 
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
### 不要な変数を削除

- rubocopからの指摘で、定義したあと使用していない変数を削除した。